### PR TITLE
feat: move to esm

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -1,8 +1,0 @@
-'use strict'
-module.exports = function (Yallist) {
-  Yallist.prototype[Symbol.iterator] = function* () {
-    for (let walker = this.head; walker; walker = walker.next) {
-      yield walker.value
-    }
-  }
-}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "yallist",
+  "type": "module",
   "version": "4.0.0",
   "description": "Yet Another Linked List",
   "main": "yallist.js",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,8 @@
-var t = require('tap')
-var Yallist = require('../yallist.js')
+import t from 'tap';
+import {
+  create as Yallist,
+  Node
+} from '../yallist.js';
 
 var y = new Yallist(1, 2, 3, 4, 5)
 var z = new Yallist([1, 2, 3, 4, 5])
@@ -151,16 +154,16 @@ inserter.pushNode(swiped.head.next)
 t.match(inserter.toArray(), [8, 2, 3, 5, 4, 1, 8])
 t.match(swiped.toArray(), [9, 7])
 
-swiped.unshiftNode(Yallist.Node(99))
+swiped.unshiftNode(Node(99))
 t.match(swiped.toArray(), [99, 9, 7])
-swiped.pushNode(Yallist.Node(66))
+swiped.pushNode(Node(66))
 t.match(swiped.toArray(), [99, 9, 7, 66])
 
 var e = Yallist()
-e.unshiftNode(Yallist.Node(1))
+e.unshiftNode(Node(1))
 t.same(e.toArray(), [1])
 e = Yallist()
-e.pushNode(Yallist.Node(1))
+e.pushNode(Node(1))
 t.same(e.toArray(), [1])
 
 // steal them back, don't break the lists
@@ -175,7 +178,7 @@ t.throws(function remove_foreign_node () {
   e.removeNode(swiped.head)
 }, {}, new Error('removing node which does not belong to this list'))
 t.throws(function remove_unlisted_node () {
-  e.removeNode(Yallist.Node('nope'))
+  e.removeNode(Node('nope'))
 }, {}, new Error('removing node which does not belong to this list'))
 
 e = Yallist(1, 2)

--- a/yallist.js
+++ b/yallist.js
@@ -1,8 +1,4 @@
 'use strict'
-module.exports = Yallist
-
-Yallist.Node = Node
-Yallist.create = Yallist
 
 function Yallist (list) {
   var self = this
@@ -364,6 +360,12 @@ Yallist.prototype.reverse = function () {
   return this
 }
 
+Yallist.prototype[Symbol.iterator] = function* () {
+  for (let walker = this.head; walker; walker = walker.next) {
+    yield walker.value
+  }
+}
+
 function insert (self, node, value) {
   var inserted = node === self.head ?
     new Node(value, null, node, self) :
@@ -420,7 +422,7 @@ function Node (value, prev, next, list) {
   }
 }
 
-try {
-  // add if support for Symbol.iterator is present
-  require('./iterator.js')(Yallist)
-} catch (er) {}
+export {
+  Yallist as create,
+  Node
+};


### PR DESCRIPTION
This migrates the project to be pure-esm, i.e. `type:  "module"`.

The iterator try/catch has also been dropped since `Symbol.iterator` is widely available now (older systems can simply stay on the older `yallist` package).

No clue what the state of this repo is, if it is maintained, etc. If you ever want this change, just let me know and i'll get it across the line with you.

It could also be a class these days, and use const/let, etc. If its worth modernising it a bit.